### PR TITLE
Problem of local-data interference: Fix for -p flag on docker and additional continuous logging added during ctrl C exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "lars": "dist/index.js"
     },
     "scripts": {
-        "build": "tsc -b"
+        "build": "tsc -b",
+        "lint": "ts-standard --fix src/**/*.ts*"
     },
     "keywords": [
         "bsv",


### PR DESCRIPTION
This is a fix for the problem of different container image's local-data interfering with each other, due to local-data being used as the dir name at the top level for all apps.